### PR TITLE
Fix crash when is_atom is sent null

### DIFF
--- a/src/low-level/imap/mailimap_sender.c
+++ b/src/low-level/imap/mailimap_sender.c
@@ -402,7 +402,10 @@ int mailimap_append_send(mailstream * fd,
 
 static int is_atom(const char * str)
 {
-  if (* str == '\0')
+  if (str == NULL)
+    return 0;
+	
+ if (* str == '\0')
     return 0;
   
   while (* str != '\0') {


### PR DESCRIPTION
I have not tested this yet but I get crash reports here for AOL accounts, etc.